### PR TITLE
fix: allow copying of rdfjs source prototype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "husky": "^6.0.0",
         "jest": "^26.0.1",
         "mkdirp": "^1.0.4",
+        "n3": "^1.10.0",
         "semantic-release": "^17.4.2",
         "setup-polly-jest": "^0.9.1"
       },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "husky": "^6.0.0",
     "jest": "^26.0.1",
     "mkdirp": "^1.0.4",
+    "n3": "^1.10.0",
     "semantic-release": "^17.4.2",
     "setup-polly-jest": "^0.9.1"
   },

--- a/src/ComunicaEngine.js
+++ b/src/ComunicaEngine.js
@@ -155,7 +155,6 @@ function assign(props, orig) {
   return Object.assign(Object.create(Object.getPrototypeOf(orig)), { ...orig, ...props });
 }
 
-
 // Flattens the given array one level deep
 async function flattenAsync(array) {
   return [].concat(...(await Promise.all(array)));

--- a/src/ComunicaEngine.js
+++ b/src/ComunicaEngine.js
@@ -62,7 +62,7 @@ export default class ComunicaEngine {
       sources = await flattenAsync(sources.map(s => this.parseSources(s)));
     // Needs to be after the string check since those also have a match functions
     else if (typeof sources.match === 'function')
-      sources = [Object.assign({ type: 'rdfjsSource' }, sources)];
+      sources = [assign({ type: 'rdfjsSource' }, sources)];
     // Wrap a single source in an array
     else if (typeof source.value === 'string')
       sources = [sources];
@@ -143,6 +143,18 @@ export default class ComunicaEngine {
     await this._engine.invalidateHttpCache(document);
   }
 }
+
+/**
+ * Extends Object.assign by also copying prototype methods
+ * @param {Object} props To add to the object
+ * @param {Object} orig Original Object
+ * @returns Copy of original object with added props
+ */
+function assign(props, orig) {
+  // https://stackoverflow.com/questions/41474986/how-to-clone-a-javascript-es6-class-instance
+  return Object.assign(Object.create(Object.getPrototypeOf(orig)), { ...orig, ...props });
+}
+
 
 // Flattens the given array one level deep
 async function flattenAsync(array) {

--- a/src/ComunicaEngine.js
+++ b/src/ComunicaEngine.js
@@ -152,7 +152,7 @@ export default class ComunicaEngine {
  */
 function assign(props, orig) {
   // https://stackoverflow.com/questions/41474986/how-to-clone-a-javascript-es6-class-instance
-  return Object.assign(Object.create(Object.getPrototypeOf(orig)), { ...orig, ...props });
+  return Object.assign(Object.create(orig), { ...orig, ...props });
 }
 
 // Flattens the given array one level deep

--- a/test/ComunicaEngine-test.js
+++ b/test/ComunicaEngine-test.js
@@ -247,7 +247,6 @@ describe('A ComunicaEngine instance with an rdfjs source (as input to execute)',
   });
 });
 
-
 describe('An ComunicaEngine instance with a default source that errors', () => {
   const engine = new ComunicaEngine(Promise.reject(new Error('my error')));
 

--- a/test/ComunicaEngine-test.js
+++ b/test/ComunicaEngine-test.js
@@ -1,7 +1,8 @@
 import ComunicaEngine from '../src/ComunicaEngine';
 
 import { mockHttp } from './util';
-import { namedNode, defaultGraph } from '@rdfjs/data-model';
+import { namedNode, defaultGraph, quad } from '@rdfjs/data-model';
+import { Store } from 'n3';
 import { Readable } from 'stream';
 
 const SELECT_TYPES = `
@@ -194,6 +195,58 @@ describe('An ComunicaEngine instance with a default source', () => {
     expect(await readAll(result)).toHaveLength(6);
   });
 });
+
+describe('A ComunicaEngine instance with an rdfjs source (in list)', () => {
+  const store = new Store([
+    quad(
+      namedNode('http://example.org/Jesse'),
+      namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      namedNode('http://xmlns.com/foaf/0.1/Person'),
+    ),
+  ]);
+
+  const engine = new ComunicaEngine([store]);
+
+  it('yields results for a SELECT query', async () => {
+    const result = engine.execute(SELECT_TYPES);
+    expect(await readAll(result)).toHaveLength(1);
+  });
+});
+
+describe('A ComunicaEngine instance with an rdfjs source', () => {
+  const store = new Store([
+    quad(
+      namedNode('http://example.org/Jesse'),
+      namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      namedNode('http://xmlns.com/foaf/0.1/Person'),
+    ),
+  ]);
+
+  const engine = new ComunicaEngine(store);
+
+  it('yields results for a SELECT query', async () => {
+    const result = engine.execute(SELECT_TYPES);
+    expect(await readAll(result)).toHaveLength(1);
+  });
+});
+
+describe('A ComunicaEngine instance with an rdfjs source (as input to execute)', () => {
+  const store = new Store([
+    quad(
+      namedNode('http://example.org/Jesse'),
+      namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      namedNode('http://xmlns.com/foaf/0.1/Person'),
+    ),
+  ]);
+
+  const engine = new ComunicaEngine();
+
+  it('yields results for a SELECT query', async () => {
+    const result = engine.execute(SELECT_TYPES, store);
+    expect(await readAll(result)).toHaveLength(1);
+  });
+});
+
 
 describe('An ComunicaEngine instance with a default source that errors', () => {
   const engine = new ComunicaEngine(Promise.reject(new Error('my error')));


### PR DESCRIPTION
Copies the object prototype of an rdfjs source so that [this](https://github.com/comunica/comunica/blob/c55516edb9ebdff601910a9f775d6f54eb7c7635/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/lib/ActorRdfResolveQuadPatternRdfJsSource.ts#L22) test passes in the comunica actor for rdfjs sources