### PR TITLE
feat/custom engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,13 @@ const context = {
     "friends": "knows",
   }
 };
+
 // The query engine and its source
-const queryEngine = new ComunicaEngine('https://ruben.verborgh.org/profile/', { options: {
-    /* add options here */
-  } });
+const queryEngine = new ComunicaEngine(
+    'https://ruben.verborgh.org/profile/',
+    { options: {/* add options here */} },
+  );
+
 // The object that can create new paths
 const paths = new PathFactory({ context, queryEngine });
 
@@ -121,6 +124,4 @@ showPerson(ruben);
 
 ## License
 ©2018–present
-[Ruben Verborgh](https://ruben.verborgh.org/),
-Joachim Van Herwegen.
-[MIT License](https://github.com/LDflex/LDflex-Comunica/blob/master/LICENSE.md).
+[Ruben Verborgh](https://ruben.verborgh.org/), Joachim Van Herwegen, [Jesse Wright](https://github.com/jeswr/). [MIT License](https://github.com/LDflex/LDflex-Comunica/blob/master/LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -45,6 +45,48 @@ const ruben = paths.create({
 showPerson(ruben);
 ```
 
+## Features
+
+### Using a Customised Comunica Engine
+
+This example uses the comunica engine for local file queries.
+
+```JavaScript
+const { PathFactory } = require('ldflex');
+const { default: ComunicaEngine } = require('@ldflex/comunica');
+const { namedNode } = require('@rdfjs/data-model');
+const { newEngine: localFileEngine } = require('@comunica/actor-init-sparql-file');
+
+// The JSON-LD context for resolving properties
+const context = {
+  "@context": {
+    "@vocab": "http://xmlns.com/foaf/0.1/",
+    "friends": "knows",
+  }
+};
+// The query engine and its source
+const queryEngine = new ComunicaEngine(
+    path.join(__dirname, 'ruben-verborgh.ttl'),
+    { engine: localFileEngine() }
+  );
+// The object that can create new paths
+const paths = new PathFactory({ context, queryEngine });
+
+async function showPerson(person) {
+  console.log(`This person is ${await person.name}`);
+
+  console.log(`${await person.givenName} is friends with:`);
+  for await (const name of person.friends.givenName)
+    console.log(`- ${name}`);
+}
+
+const ruben = paths.create({
+  subject: namedNode('https://ruben.verborgh.org/profile/#me'),
+});
+showPerson(ruben);
+```
+
+
 ## License
 ©2018–present
 [Ruben Verborgh](https://ruben.verborgh.org/),

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ showPerson(ruben);
 
 ## Features
 
-### Using a Customised Comunica Engine
+### Using a customised ComunicaEngine
 
 This example uses the comunica engine for local file queries.
 
@@ -85,7 +85,39 @@ const ruben = paths.create({
 });
 showPerson(ruben);
 ```
+### Adding custom options to the ComunicaEngine
+```JavaScript
+const { PathFactory } = require('ldflex');
+const { default: ComunicaEngine } = require('@ldflex/comunica');
+const { namedNode } = require('@rdfjs/data-model');
 
+// The JSON-LD context for resolving properties
+const context = {
+  "@context": {
+    "@vocab": "http://xmlns.com/foaf/0.1/",
+    "friends": "knows",
+  }
+};
+// The query engine and its source
+const queryEngine = new ComunicaEngine('https://ruben.verborgh.org/profile/', { options: {
+    /* add options here */
+  } });
+// The object that can create new paths
+const paths = new PathFactory({ context, queryEngine });
+
+async function showPerson(person) {
+  console.log(`This person is ${await person.name}`);
+
+  console.log(`${await person.givenName} is friends with:`);
+  for await (const name of person.friends.givenName)
+    console.log(`- ${name}`);
+}
+
+const ruben = paths.create({
+  subject: namedNode('https://ruben.verborgh.org/profile/#me'),
+});
+showPerson(ruben);
+```
 
 ## License
 ©2018–present

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ const ruben = paths.create({
 showPerson(ruben);
 ```
 ### Adding custom options to the ComunicaEngine
+
+Add [comunica context options](https://comunica.dev/docs/query/advanced/context/) which are passed to the Comunica Engine. 
+
 ```JavaScript
 const { PathFactory } = require('ldflex');
 const { default: ComunicaEngine } = require('@ldflex/comunica');

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@babel/cli": "^7.8.4",
         "@babel/core": "^7.9.6",
         "@babel/preset-env": "^7.9.6",
+        "@comunica/actor-init-sparql-file": "^1.21.3",
+        "@comunica/actor-init-sparql-rdfjs": "^1.21.3",
         "@pollyjs/adapter-node-http": "^5.1.1",
         "@pollyjs/core": "^4.2.1",
         "@pollyjs/persister-fs": "^5.1.1",
@@ -2159,6 +2161,85 @@
         "comunica-sparql-http": "bin/http.js"
       }
     },
+    "node_modules/@comunica/actor-init-sparql-file": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-file/-/actor-init-sparql-file-1.21.3.tgz",
+      "integrity": "sha512-NuusIhT9Eyg7c3QJA4XKxty85gtHhNHL2Wx4l4EU72ge6qRFUUzVghVlsFCDCgaqNiiFYV4/HaMmpB8vMJEu0g==",
+      "dev": true,
+      "dependencies": {
+        "@comunica/actor-init-sparql": "^1.21.3",
+        "@comunica/actor-rdf-dereference-file": "^1.21.1",
+        "@comunica/runner-cli": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
+      },
+      "bin": {
+        "comunica-dynamic-sparql-file": "bin/query-dynamic.js",
+        "comunica-sparql-file": "bin/query.js",
+        "comunica-sparql-file-http": "bin/http.js"
+      }
+    },
+    "node_modules/@comunica/actor-init-sparql-rdfjs": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.21.3.tgz",
+      "integrity": "sha512-x2LWKS/qRGZetZGiKGKzKEYr/yb6nEw4KGPbpYo6N4Jp0BvTigiEPYx3HhOaEjeYCONgd/3j3JO5vefFIFNE2w==",
+      "dev": true,
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^1.21.1",
+        "@comunica/actor-init-sparql": "^1.21.3",
+        "@comunica/actor-query-operation-ask": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-empty": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.2",
+        "@comunica/actor-query-operation-bgp-single": "^1.21.1",
+        "@comunica/actor-query-operation-construct": "^1.21.1",
+        "@comunica/actor-query-operation-describe-subject": "^1.21.1",
+        "@comunica/actor-query-operation-distinct-hash": "^1.21.1",
+        "@comunica/actor-query-operation-extend": "^1.21.2",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.2",
+        "@comunica/actor-query-operation-from-quad": "^1.21.1",
+        "@comunica/actor-query-operation-join": "^1.21.1",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.2",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.2",
+        "@comunica/actor-query-operation-path-alt": "^1.21.1",
+        "@comunica/actor-query-operation-path-inv": "^1.21.1",
+        "@comunica/actor-query-operation-path-link": "^1.21.1",
+        "@comunica/actor-query-operation-path-nps": "^1.21.1",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.21.1",
+        "@comunica/actor-query-operation-path-seq": "^1.21.1",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.21.1",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.21.1",
+        "@comunica/actor-query-operation-project": "^1.21.1",
+        "@comunica/actor-query-operation-quadpattern": "^1.21.1",
+        "@comunica/actor-query-operation-service": "^1.21.1",
+        "@comunica/actor-query-operation-slice": "^1.21.1",
+        "@comunica/actor-query-operation-union": "^1.21.1",
+        "@comunica/actor-query-operation-values": "^1.21.1",
+        "@comunica/actor-rdf-join-nestedloop": "^1.21.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.21.1",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.21.1",
+        "@comunica/actor-rdf-serialize-n3": "^1.21.1",
+        "@comunica/actor-sparql-parse-algebra": "^1.21.1",
+        "@comunica/actor-sparql-serialize-json": "^1.21.1",
+        "@comunica/actor-sparql-serialize-rdf": "^1.21.1",
+        "@comunica/actor-sparql-serialize-simple": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.21.1",
+        "@comunica/bus-context-preprocess": "^1.21.1",
+        "@comunica/bus-init": "^1.21.1",
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/bus-rdf-join": "^1.21.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/bus-rdf-serialize": "^1.21.1",
+        "@comunica/bus-sparql-parse": "^1.21.1",
+        "@comunica/bus-sparql-serialize": "^1.21.1",
+        "@comunica/core": "^1.21.1",
+        "@comunica/mediator-combine-pipeline": "^1.21.1",
+        "@comunica/mediator-combine-union": "^1.21.1",
+        "@comunica/mediator-number": "^1.21.1",
+        "@comunica/mediator-race": "^1.21.1",
+        "@comunica/runner": "^1.21.1",
+        "@comunica/runner-cli": "^1.21.1"
+      }
+    },
     "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
       "version": "1.21.1",
       "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.21.1.tgz",
@@ -2793,6 +2874,17 @@
       "peerDependencies": {
         "@comunica/bus-rdf-dereference": "^1.19.2",
         "@comunica/core": "^1.19.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-dereference-file": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-file/-/actor-rdf-dereference-file-1.21.1.tgz",
+      "integrity": "sha512-9RAY4tpxzJHLsWjJsa0NnDs0EbWQChf4wfrCn61OgGRpJrVd6LFqQWZCcs//yQsAmHJCMHeoZMpRkTeQTutLIQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@comunica/bus-rdf-dereference": "^1.0.0",
+        "@comunica/bus-rdf-parse": "^1.0.0",
+        "@comunica/core": "^1.0.0"
       }
     },
     "node_modules/@comunica/actor-rdf-dereference-http-parse": {
@@ -25377,6 +25469,80 @@
         "streamify-string": "^1.0.1"
       }
     },
+    "@comunica/actor-init-sparql-file": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-file/-/actor-init-sparql-file-1.21.3.tgz",
+      "integrity": "sha512-NuusIhT9Eyg7c3QJA4XKxty85gtHhNHL2Wx4l4EU72ge6qRFUUzVghVlsFCDCgaqNiiFYV4/HaMmpB8vMJEu0g==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-init-sparql": "^1.21.3",
+        "@comunica/actor-rdf-dereference-file": "^1.21.1",
+        "@comunica/runner-cli": "^1.21.1",
+        "sparqlalgebrajs": "^2.5.5"
+      }
+    },
+    "@comunica/actor-init-sparql-rdfjs": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql-rdfjs/-/actor-init-sparql-rdfjs-1.21.3.tgz",
+      "integrity": "sha512-x2LWKS/qRGZetZGiKGKzKEYr/yb6nEw4KGPbpYo6N4Jp0BvTigiEPYx3HhOaEjeYCONgd/3j3JO5vefFIFNE2w==",
+      "dev": true,
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^1.21.1",
+        "@comunica/actor-init-sparql": "^1.21.3",
+        "@comunica/actor-query-operation-ask": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-empty": "^1.21.1",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.21.2",
+        "@comunica/actor-query-operation-bgp-single": "^1.21.1",
+        "@comunica/actor-query-operation-construct": "^1.21.1",
+        "@comunica/actor-query-operation-describe-subject": "^1.21.1",
+        "@comunica/actor-query-operation-distinct-hash": "^1.21.1",
+        "@comunica/actor-query-operation-extend": "^1.21.2",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.21.2",
+        "@comunica/actor-query-operation-from-quad": "^1.21.1",
+        "@comunica/actor-query-operation-join": "^1.21.1",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.21.2",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.21.2",
+        "@comunica/actor-query-operation-path-alt": "^1.21.1",
+        "@comunica/actor-query-operation-path-inv": "^1.21.1",
+        "@comunica/actor-query-operation-path-link": "^1.21.1",
+        "@comunica/actor-query-operation-path-nps": "^1.21.1",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.21.1",
+        "@comunica/actor-query-operation-path-seq": "^1.21.1",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.21.1",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.21.1",
+        "@comunica/actor-query-operation-project": "^1.21.1",
+        "@comunica/actor-query-operation-quadpattern": "^1.21.1",
+        "@comunica/actor-query-operation-service": "^1.21.1",
+        "@comunica/actor-query-operation-slice": "^1.21.1",
+        "@comunica/actor-query-operation-union": "^1.21.1",
+        "@comunica/actor-query-operation-values": "^1.21.1",
+        "@comunica/actor-rdf-join-nestedloop": "^1.21.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.21.1",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.21.1",
+        "@comunica/actor-rdf-serialize-n3": "^1.21.1",
+        "@comunica/actor-sparql-parse-algebra": "^1.21.1",
+        "@comunica/actor-sparql-serialize-json": "^1.21.1",
+        "@comunica/actor-sparql-serialize-rdf": "^1.21.1",
+        "@comunica/actor-sparql-serialize-simple": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.21.1",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.21.1",
+        "@comunica/bus-context-preprocess": "^1.21.1",
+        "@comunica/bus-init": "^1.21.1",
+        "@comunica/bus-query-operation": "^1.21.1",
+        "@comunica/bus-rdf-join": "^1.21.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.21.1",
+        "@comunica/bus-rdf-serialize": "^1.21.1",
+        "@comunica/bus-sparql-parse": "^1.21.1",
+        "@comunica/bus-sparql-serialize": "^1.21.1",
+        "@comunica/core": "^1.21.1",
+        "@comunica/mediator-combine-pipeline": "^1.21.1",
+        "@comunica/mediator-combine-union": "^1.21.1",
+        "@comunica/mediator-number": "^1.21.1",
+        "@comunica/mediator-race": "^1.21.1",
+        "@comunica/runner": "^1.21.1",
+        "@comunica/runner-cli": "^1.21.1"
+      }
+    },
     "@comunica/actor-optimize-query-operation-join-bgp": {
       "version": "1.21.1",
       "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.21.1.tgz",
@@ -25835,6 +26001,13 @@
       "version": "1.21.1",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-fallback/-/actor-rdf-dereference-fallback-1.21.1.tgz",
       "integrity": "sha512-iXaC7/jUWMJQKoNa9Hm4UouXTJfER/jyK7HQ0q9ddkLvXYTWwcltnnLxs+dXQRbpUZm8NvP/LPUC3H1G85Tzwg==",
+      "requires": {}
+    },
+    "@comunica/actor-rdf-dereference-file": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-file/-/actor-rdf-dereference-file-1.21.1.tgz",
+      "integrity": "sha512-9RAY4tpxzJHLsWjJsa0NnDs0EbWQChf4wfrCn61OgGRpJrVd6LFqQWZCcs//yQsAmHJCMHeoZMpRkTeQTutLIQ==",
+      "dev": true,
       "requires": {}
     },
     "@comunica/actor-rdf-dereference-http-parse": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint": "^7.0.0",
         "eslint-plugin-jest": "^24.3.6",
         "husky": "^6.0.0",
-        "jest": "^26.0.1",
+        "jest": "^26.6.3",
         "mkdirp": "^1.0.4",
         "n3": "^1.10.0",
         "semantic-release": "^17.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@babel/cli": "^7.8.4",
         "@babel/core": "^7.9.6",
         "@babel/preset-env": "^7.9.6",
+        "@comunica/actor-http-proxy": "^1.21.1",
         "@comunica/actor-init-sparql-file": "^1.21.3",
         "@comunica/actor-init-sparql-rdfjs": "^1.21.3",
         "@pollyjs/adapter-node-http": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "husky": "^6.0.0",
         "jest": "^26.0.1",
         "mkdirp": "^1.0.4",
+        "n3": "^1.10.0",
         "semantic-release": "^17.4.2",
         "setup-polly-jest": "^0.9.1"
       },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "husky": "^6.0.0",
     "jest": "^26.0.1",
     "mkdirp": "^1.0.4",
+    "n3": "^1.10.0",
     "semantic-release": "^17.4.2",
     "setup-polly-jest": "^0.9.1"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint": "^7.0.0",
     "eslint-plugin-jest": "^24.3.6",
     "husky": "^6.0.0",
-    "jest": "^26.0.1",
+    "jest": "^26.6.3",
     "mkdirp": "^1.0.4",
     "n3": "^1.10.0",
     "semantic-release": "^17.4.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
+    "@comunica/actor-http-proxy": "^1.21.1",
     "@comunica/actor-init-sparql-file": "^1.21.3",
     "@comunica/actor-init-sparql-rdfjs": "^1.21.3",
     "@pollyjs/adapter-node-http": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
+    "@comunica/actor-init-sparql-file": "^1.21.3",
+    "@comunica/actor-init-sparql-rdfjs": "^1.21.3",
     "@pollyjs/adapter-node-http": "^5.1.1",
     "@pollyjs/core": "^4.2.1",
     "@pollyjs/persister-fs": "^5.1.1",

--- a/src/ComunicaEngine.js
+++ b/src/ComunicaEngine.js
@@ -10,11 +10,12 @@ export default class ComunicaEngine {
    * The default source can be a single URL, an RDF/JS Datasource,
    * or an array with any of these.
    */
-  constructor(defaultSource) {
-    this._engine = DefaultEngine;
+  constructor(defaultSource, settings = {}) {
+    this._engine = settings.engine ? settings.engine : DefaultEngine;
     // Preload sources but silence errors; they will be thrown during execution
     this._sources = this.parseSources(defaultSource);
     this._sources.catch(() => null);
+    this._options = settings.options ? settings.options : {};
   }
 
   /**

--- a/src/ComunicaEngine.js
+++ b/src/ComunicaEngine.js
@@ -155,7 +155,6 @@ function assign(props, orig) {
   return Object.assign(Object.create(Object.getPrototypeOf(orig)), { ...orig, ...props });
 }
 
-
 // Flattens the given array one level deep
 async function flattenAsync(array) {
   return [].concat(...(await Promise.all(array)));

--- a/src/ComunicaEngine.js
+++ b/src/ComunicaEngine.js
@@ -62,7 +62,7 @@ export default class ComunicaEngine {
       sources = await flattenAsync(sources.map(s => this.parseSources(s)));
     // Needs to be after the string check since those also have a match functions
     else if (typeof sources.match === 'function')
-      sources = [Object.assign({ type: 'rdfjsSource' }, sources)];
+      sources = [assign({ type: 'rdfjsSource' }, sources)];
     // Wrap a single source in an array
     else if (typeof source.value === 'string')
       sources = [sources];
@@ -143,6 +143,18 @@ export default class ComunicaEngine {
     await this._engine.invalidateHttpCache(document);
   }
 }
+
+/**
+ * Extends Object.assign by also copying prototype methods
+ * @param {Object} props To add to the object
+ * @param {Object} orig Original Object
+ * @returns Copy of original object with added props
+ */
+function assign(props, orig) {
+  // https://stackoverflow.com/questions/41474986/how-to-clone-a-javascript-es6-class-instance
+  return Object.assign(Object.create(Object.getPrototypeOf(orig)), { ...orig, ...props });
+}
+
 
 // Flattens the given array one level deep
 async function flattenAsync(array) {

--- a/src/ComunicaEngine.js
+++ b/src/ComunicaEngine.js
@@ -29,7 +29,7 @@ export default class ComunicaEngine {
     const sources = await (source ? this.parseSources(source) : this._sources);
     if (sources.length !== 0) {
       // Execute the query and yield the results
-      const queryResult = await this._engine.query(sparql, { sources });
+      const queryResult = await this._engine.query(sparql, { sources, ...this._options });
       yield* this.streamToAsyncIterable(queryResult.bindingsStream);
     }
   }

--- a/test/ComunicaEngine-test.js
+++ b/test/ComunicaEngine-test.js
@@ -247,7 +247,6 @@ describe('A ComunicaEngine instance with an rdfjs source (as input to execute)',
   });
 });
 
-
 describe('An ComunicaEngine instance with a default source that errors', () => {
   const engine = new ComunicaEngine(Promise.reject(new Error('my error')));
 

--- a/test/ComunicaEngine-test.js
+++ b/test/ComunicaEngine-test.js
@@ -1,7 +1,8 @@
 import ComunicaEngine from '../src/ComunicaEngine';
 
 import { mockHttp } from './util';
-import { namedNode, defaultGraph } from '@rdfjs/data-model';
+import { namedNode, defaultGraph, quad } from '@rdfjs/data-model';
+import { Store } from 'n3';
 import { Readable } from 'stream';
 
 const SELECT_TYPES = `
@@ -194,6 +195,58 @@ describe('An ComunicaEngine instance with a default source', () => {
     expect(await readAll(result)).toHaveLength(6);
   });
 });
+
+describe('A ComunicaEngine instance with an rdfjs source (in list)', () => {
+  const store = new Store([
+    quad(
+      namedNode('http://example.org/Jesse'),
+      namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      namedNode('http://xmlns.com/foaf/0.1/Person'),
+    ),
+  ]);
+
+  const engine = new ComunicaEngine([store]);
+
+  it('yields results for a SELECT query', async () => {
+    const result = engine.execute(SELECT_TYPES);
+    expect(await readAll(result)).toHaveLength(1);
+  });
+});
+
+describe('A ComunicaEngine instance with an rdfjs source', () => {
+  const store = new Store([
+    quad(
+      namedNode('http://example.org/Jesse'),
+      namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      namedNode('http://xmlns.com/foaf/0.1/Person'),
+    ),
+  ]);
+
+  const engine = new ComunicaEngine(store);
+
+  it('yields results for a SELECT query', async () => {
+    const result = engine.execute(SELECT_TYPES);
+    expect(await readAll(result)).toHaveLength(1);
+  });
+});
+
+describe('A ComunicaEngine instance with an rdfjs source (as input to execute)', () => {
+  const store = new Store([
+    quad(
+      namedNode('http://example.org/Jesse'),
+      namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      namedNode('http://xmlns.com/foaf/0.1/Person'),
+    ),
+  ]);
+
+  const engine = new ComunicaEngine();
+
+  it('yields results for a SELECT query', async () => {
+    const result = engine.execute(SELECT_TYPES, store);
+    expect(await readAll(result)).toHaveLength(1);
+  });
+});
+
 
 describe('An ComunicaEngine instance with a default source that errors', () => {
   const engine = new ComunicaEngine(Promise.reject(new Error('my error')));

--- a/test/ComunicaEngine-test.js
+++ b/test/ComunicaEngine-test.js
@@ -1,6 +1,6 @@
 import ComunicaEngine from '../src/ComunicaEngine';
 
-import { mockHttp } from './util';
+import { mockHttp, readAll } from './util';
 import { namedNode, defaultGraph, quad } from '@rdfjs/data-model';
 import { Store } from 'n3';
 import { Readable } from 'stream';
@@ -255,10 +255,3 @@ describe('An ComunicaEngine instance with a default source that errors', () => {
     await expect(readAll(result)).rejects.toThrow('my error');
   });
 });
-
-async function readAll(asyncIterator) {
-  const items = [];
-  for await (const item of asyncIterator)
-    items.push(item);
-  return items;
-}

--- a/test/CustomComunicaEngine-test.js
+++ b/test/CustomComunicaEngine-test.js
@@ -1,0 +1,57 @@
+import ComunicaEngine from '../src/ComunicaEngine';
+
+import { readAll } from './util';
+import { namedNode, quad } from '@rdfjs/data-model';
+import { newEngine as localFileEngine } from '@comunica/actor-init-sparql-file';
+import { newEngine as rdfjsFileEngine } from '@comunica/actor-init-sparql-rdfjs';
+import { Store } from 'n3';
+import path from 'path';
+
+const SELECT_TYPES = `
+  SELECT ?subject ?type WHERE {
+    ?subject a ?type.
+  }
+`;
+
+const PROFILE_URL = 'https://www.w3.org/People/Berners-Lee/card#i';
+
+describe('An ComunicaEngine with local file engine configuration', () => {
+  const engine = new ComunicaEngine(path.join(__dirname, 'data', 'berners-lee.ttl'), { engine: localFileEngine() });
+
+  it('yields results for a SELECT query with a string URL', async () => {
+    const result = engine.execute(SELECT_TYPES);
+    expect(await readAll(result)).toHaveLength(6);
+  });
+});
+
+describe('An ComunicaEngine with local file engine configuration & custom options', () => {
+  const engine = new ComunicaEngine([], {
+    engine: localFileEngine(),
+    options: {
+      sources: [path.join(__dirname, 'data', 'berners-lee.ttl')],
+    },
+  });
+
+  it('yields results for a SELECT query with a string URL', async () => {
+    // Need at least one source (not in options) so engine gets called
+    const result = engine.execute(SELECT_TYPES, PROFILE_URL);
+    expect(await readAll(result)).toHaveLength(6);
+  });
+});
+
+describe('A ComunicaEngine instance with a custom rdfjs engine', () => {
+  const store = new Store([
+    quad(
+      namedNode('http://example.org/Jesse'),
+      namedNode('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+      namedNode('http://xmlns.com/foaf/0.1/Person'),
+    ),
+  ]);
+
+  const engine = new ComunicaEngine([], { engine: rdfjsFileEngine() });
+
+  it('yields results for a SELECT query', async () => {
+    const result = engine.execute(SELECT_TYPES, store);
+    expect(await readAll(result)).toHaveLength(1);
+  });
+});

--- a/test/CustomComunicaEngine-test.js
+++ b/test/CustomComunicaEngine-test.js
@@ -13,8 +13,6 @@ const SELECT_TYPES = `
   }
 `;
 
-const PROFILE_URL = 'https://www.w3.org/People/Berners-Lee/card#i';
-
 describe('An ComunicaEngine with local file engine configuration', () => {
   const engine = new ComunicaEngine(path.join(__dirname, 'data', 'berners-lee.ttl'), { engine: localFileEngine() });
 
@@ -34,7 +32,7 @@ describe('An ComunicaEngine with local file engine configuration & custom option
 
   it('yields results for a SELECT query with a string URL', async () => {
     // Need at least one source (not in options) so engine gets called
-    const result = engine.execute(SELECT_TYPES, PROFILE_URL);
+    const result = engine.execute(SELECT_TYPES, 'http://example.org');
     expect(await readAll(result)).toHaveLength(6);
   });
 });

--- a/test/Options-test.js
+++ b/test/Options-test.js
@@ -1,0 +1,74 @@
+import ComunicaEngine from '../src/ComunicaEngine';
+
+import { readAll } from './util';
+import { namedNode, quad } from '@rdfjs/data-model';
+import { newEngine as localFileEngine } from '@comunica/actor-init-sparql-file';
+import { newEngine as rdfjsFileEngine } from '@comunica/actor-init-sparql-rdfjs';
+import { Store } from 'n3';
+import path from 'path';
+import http from 'http';
+import { ProxyHandlerStatic } from "@comunica/actor-http-proxy";
+
+const SELECT_TYPES = `
+  SELECT ?subject ?type WHERE {
+    ?subject a ?type.
+  }
+`;
+
+// describe('Testing proxy', () => {
+//   function requestListener(req, res) {
+//     console.log('request recieved')
+//     res.writeHead(200);
+//     res.end('Hello, World!');
+//   }
+
+//   const requestListenerSpy = jest.s
+
+//   const server = http.createServer(requestListenerSpy);
+//   beforeEach(() => {
+//     server.listen(8080);
+//   });
+
+//   afterEach(() => {
+//     server.close();
+//   });
+
+//   const engine = new ComunicaEngine(
+//     'https://www.w3.org/People/Berners-Lee/card#i',
+//     {
+//       options: {
+//         httpProxyHandler: new ProxyHandlerStatic('http://localhost:8080/'),
+//       },
+//     },
+//   );
+
+//   it('yields results for a SELECT query with a string URL', async () => {
+//     const result = engine.execute(SELECT_TYPES);
+//     expect(requestListenerSpy).toHaveBeenCalled();
+//     expect(await readAll(result)).toHaveLength(6);
+//   });
+// });
+
+describe('An ComunicaEngine with local file engine configuration', () => {
+  const engine = new ComunicaEngine(
+    path.join(__dirname, 'data', 'jesse.ttl'),
+    {
+      engine: localFileEngine(),
+      options: {
+        baseIRI: 'http://example.org/',
+      },
+    },
+  );
+
+  it('yields results for a SELECT query', async () => {
+    const result = await readAll(engine.execute(SELECT_TYPES));
+    expect(result).toHaveLength(1);
+    expect(result[0].get('?type').value).toEqual('http://example.org/Person');
+  });
+
+  it('yields results for a SELECT query with relative URIs', async () => {
+    const result = await readAll(engine.execute('SELECT ?subject WHERE { ?subject a <Person> } '));
+    expect(result).toHaveLength(1);
+    expect(result[0].get('?subject').value).toEqual('http://example.org/Jesse');
+  });
+});

--- a/test/Options-test.js
+++ b/test/Options-test.js
@@ -1,53 +1,14 @@
 import ComunicaEngine from '../src/ComunicaEngine';
 
 import { readAll } from './util';
-import { namedNode, quad } from '@rdfjs/data-model';
 import { newEngine as localFileEngine } from '@comunica/actor-init-sparql-file';
-import { newEngine as rdfjsFileEngine } from '@comunica/actor-init-sparql-rdfjs';
-import { Store } from 'n3';
 import path from 'path';
-import http from 'http';
-import { ProxyHandlerStatic } from "@comunica/actor-http-proxy";
 
 const SELECT_TYPES = `
   SELECT ?subject ?type WHERE {
     ?subject a ?type.
   }
 `;
-
-// describe('Testing proxy', () => {
-//   function requestListener(req, res) {
-//     console.log('request recieved')
-//     res.writeHead(200);
-//     res.end('Hello, World!');
-//   }
-
-//   const requestListenerSpy = jest.s
-
-//   const server = http.createServer(requestListenerSpy);
-//   beforeEach(() => {
-//     server.listen(8080);
-//   });
-
-//   afterEach(() => {
-//     server.close();
-//   });
-
-//   const engine = new ComunicaEngine(
-//     'https://www.w3.org/People/Berners-Lee/card#i',
-//     {
-//       options: {
-//         httpProxyHandler: new ProxyHandlerStatic('http://localhost:8080/'),
-//       },
-//     },
-//   );
-
-//   it('yields results for a SELECT query with a string URL', async () => {
-//     const result = engine.execute(SELECT_TYPES);
-//     expect(requestListenerSpy).toHaveBeenCalled();
-//     expect(await readAll(result)).toHaveLength(6);
-//   });
-// });
 
 describe('An ComunicaEngine with local file engine configuration', () => {
   const engine = new ComunicaEngine(

--- a/test/data/berners-lee.ttl
+++ b/test/data/berners-lee.ttl
@@ -1,0 +1,124 @@
+     @prefix : <http://xmlns.com/foaf/0.1/> .
+    @prefix B: <https://www.w3.org/People/Berners-Lee/> .
+    @prefix Be: <./> .
+    @prefix Pub: <https://timbl.com/timbl/Public/> .
+    @prefix blog: <http://dig.csail.mit.edu/breadcrumbs/blog/> .
+    @prefix card: <https://www.w3.org/People/Berners-Lee/card#> .
+    @prefix cc: <http://creativecommons.org/ns#> .
+    @prefix cert: <http://www.w3.org/ns/auth/cert#> .
+    @prefix con: <http://www.w3.org/2000/10/swap/pim/contact#> .
+    @prefix dc: <http://purl.org/dc/elements/1.1/> .
+    @prefix dct: <http://purl.org/dc/terms/> .
+    @prefix doap: <http://usefulinc.com/ns/doap#> .
+    @prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+    @prefix ldp: <http://www.w3.org/ns/ldp#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix s: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix schema: <http://schema.org/> .
+    @prefix sioc: <http://rdfs.org/sioc/ns#> .
+    @prefix solid: <http://www.w3.org/ns/solid/terms#> .
+    @prefix space: <http://www.w3.org/ns/pim/space#> .
+    @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+    @prefix w3c: <http://www.w3.org/data#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+    
+    <../../DesignIssues/Overview.html>     dc:title "Design Issues for the World Wide Web";
+         :maker card:i .
+    
+    <>     rdf:type :PersonalProfileDocument;
+         cc:license <http://creativecommons.org/licenses/by-nc/3.0/>;
+         dc:title "Tim Berners-Lee's FOAF file";
+         :maker card:i;
+         :primaryTopic card:i .
+    
+    <#i>     cert:key  [
+             rdf:type cert:RSAPublicKey;
+             cert:exponent 65537;
+             cert:modulus "ebe99c737bd3670239600547e5e2eb1d1497da39947b6576c3c44ffeca32cf0f2f7cbee3c47001278a90fc7fc5bcf292f741eb1fcd6bbe7f90650afb519cf13e81b2bffc6e02063ee5a55781d420b1dfaf61c15758480e66d47fb0dcb5fa7b9f7f1052e5ccbd01beee9553c3b6b51f4daf1fce991294cd09a3d1d636bc6c7656e4455d0aff06daec740ed0084aa6866fcae1359de61cc12dbe37c8fa42e977c6e727a8258bb9a3f265b27e3766fe0697f6aa0bcc81c3f026e387bd7bbc81580dc1853af2daa099186a9f59da526474ef6ec0a3d84cf400be3261b6b649dea1f78184862d34d685d2d587f09acc14cd8e578fdd2283387821296f0af39b8d8845"^^xsd:hexBinary ] .
+    
+    <http://dig.csail.mit.edu/2005/ajar/ajaw/data#Tabulator>     doap:developer card:i .
+    
+    <http://dig.csail.mit.edu/2007/01/camp/data#course>     :maker card:i .
+    
+    blog:4     dc:title "timbl's blog on DIG";
+         s:seeAlso <http://dig.csail.mit.edu/breadcrumbs/blog/feed/4>;
+         :maker card:i .
+    
+    <http://dig.csail.mit.edu/data#DIG>     :member card:i .
+    
+    <http://wiki.ontoworld.org/index.php/_IRW2006>     dc:title "Identity, Reference and the Web workshop 2006";
+         con:participant card:i .
+    
+    <http://www.ecs.soton.ac.uk/~dt2/dlstuff/www2006_data#panel-panelk01>     s:label "The Next Wave of the Web (Plenary Panel)";
+         con:participant card:i .
+    
+    <http://www.w3.org/2000/10/swap/data#Cwm>     doap:developer card:i .
+    
+    <http://www.w3.org/2011/Talks/0331-hyderabad-tbl/data#talk>     dct:title "Designing the Web for an Open Society";
+         :maker card:i .
+    
+    w3c:W3C     :member card:i .
+    
+    <https://timbl.com/timbl/Public/friends.ttl>     rdf:type :PersonalProfileDocument;
+         cc:license <http://creativecommons.org/licenses/by-nc/3.0/>;
+         dc:title "Tim Berners-Lee's editable profile";
+         :maker card:i;
+         :primaryTopic card:i .
+    
+    card:i     rdf:type con:Male,
+                :Person;
+         sioc:avatar <images/timbl-image-by-Coz-cropped.jpg>;
+         schema:owns <https://timblbot.inrupt.net/profile/card#me>;
+         s:label "Tim Berners-Lee";
+         s:seeAlso <https://timbl.com/timbl/Public/friends.ttl>;
+         con:assistant card:amy;
+         con:homePage Be:;
+         con:office  [
+             con:address  [
+                 con:city "Cambridge";
+                 con:country "USA";
+                 con:postalCode "02139";
+                 con:street "32 Vassar Street";
+                 con:street2 "MIT CSAIL Building 32" ];
+             geo:location  [
+                 geo:lat "42.361860";
+                 geo:long "-71.091840" ] ];
+         con:preferredURI "https://www.w3.org/People/Berners-Lee/card#i";
+         con:publicHomePage Be:;
+         vcard:fn "Tim Berners-Lee";
+         vcard:hasAddress  [
+             rdf:type vcard:Work;
+             vcard:locality "Cambridge";
+             vcard:postal-code "02139";
+             vcard:region "MA";
+             vcard:street-address "32 Vassar Street" ];
+         ldp:inbox Pub:Inbox;
+         space:preferencesFile <https://timbl.com/timbl/Data/preferences.n3>;
+         space:storage Pub:,
+                <https://timbl.inrupt.net/>,
+                <https://timbl.solid.community/>;
+         solid:editableProfile <https://timbl.com/timbl/Public/friends.ttl>;
+         solid:oidcIssuer <https://timbl.com>;
+         solid:profileBackgroundColor "#ffffff";
+         solid:profileHighlightColor "#00467E";
+         solid:publicTypeIndex <https://timbl.com/timbl/Public/PublicTypeIndex.ttl>;
+         :account <http://en.wikipedia.org/wiki/User:Timbl>,
+                <http://twitter.com/timberners_lee>,
+                <http://www.reddit.com/user/timbl/>;
+         :based_near  [
+             geo:lat "42.361860";
+             geo:long "-71.091840" ];
+         :family_name "Berners-Lee";
+         :givenname "Timothy";
+         :homepage B:;
+         :img <https://www.w3.org/Press/Stock/Berners-Lee/2001-europaeum-eighth.jpg>;
+         :mbox <mailto:timbl@w3.org>;
+         :mbox_sha1sum "965c47c5a70db7407210cef6e4e6f5374a525c5c";
+         :name "Timothy Berners-Lee";
+         :nick "TimBL",
+                "timbl";
+         :openid B:;
+         :title "Sir";
+         :weblog blog:4;
+         :workplaceHomepage <https://www.w3.org/> .
+    

--- a/test/data/jesse.ttl
+++ b/test/data/jesse.ttl
@@ -1,0 +1,1 @@
+<http://example.org/Jesse> a <http://example.org/Person> .

--- a/test/util.js
+++ b/test/util.js
@@ -18,3 +18,10 @@ export function mockHttp() {
     recordFailedRequests: true,
   });
 }
+
+export async function readAll(asyncIterator) {
+  const items = [];
+  for await (const item of asyncIterator)
+    items.push(item);
+  return items;
+}


### PR DESCRIPTION
Adds functionality to allow usage of a custom ComunicaEngine instead of the default engine.
Also includes functionality to apply custom options suggested in https://github.com/LDflex/LDflex-Comunica/pull/21.

A potential improvement is to add further test cases for the custom options feature @danielbeeke, did you have any particular cases in mind?

This should be merged *after* https://github.com/LDflex/LDflex-Comunica/pull/36.
