### PR TITLE
feature: add update support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ const ruben = paths.create({
 showPerson(ruben);
 ```
 
+### Updating data
+By default the source given is also used as the destination for updates (if multiple sources are given, then the first one is chosen).
+
+Optionally you can specify your own destination for updates as follows
+
+```JavaScript
+// The query engine and its source
+const queryEngine = new ComunicaEngine(
+    'https://ruben.verborgh.org/profile/',
+    { destination: 'https://example.org/destination' },
+  );
+```
+
 ## License
 ©2018–present
 [Ruben Verborgh](https://ruben.verborgh.org/), Joachim Van Herwegen, [Jesse Wright](https://github.com/jeswr/). [MIT License](https://github.com/LDflex/LDflex-Comunica/blob/master/LICENSE.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-plugin-jest": "^25.3.0",
         "husky": "^7.0.4",
         "jest": "^27.4.5",
+        "ldflex": "^2.13.1",
         "mkdirp": "^1.0.4",
         "n3": "^1.12.2",
         "semantic-release": "^18.0.1",
@@ -4817,6 +4818,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
       "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dev": true,
       "dependencies": {
         "@rdfjs/types": ">=1.0.1"
       },
@@ -10947,7 +10949,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/ldflex/-/ldflex-2.13.1.tgz",
       "integrity": "sha512-bRpDundyMeY18EQb6BLs/BEHUUIkzt0Lq1GPLq5zMSCu49p8phKNx/XQ6cYeJKrmV6R4aVMcqeYK6oTCNuUQYQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@rdfjs/data-model": "^1.3.4",
         "jsonld-context-parser": "^2.1.5",
@@ -10958,7 +10960,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.1.tgz",
       "integrity": "sha512-/YOn4+5JEawI29h9eFYb9rScCtiLIK4TG+MrXpbJlHDjL8W34+V/RQoXqeau4SFXtA60Vzc7LRokefguh+I37Q==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@rdfjs/types": "*",
         "@types/sparqljs": "^3.1.3",
@@ -21161,6 +21163,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
       "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dev": true,
       "requires": {
         "@rdfjs/types": ">=1.0.1"
       }
@@ -25795,7 +25798,7 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/ldflex/-/ldflex-2.13.1.tgz",
       "integrity": "sha512-bRpDundyMeY18EQb6BLs/BEHUUIkzt0Lq1GPLq5zMSCu49p8phKNx/XQ6cYeJKrmV6R4aVMcqeYK6oTCNuUQYQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@rdfjs/data-model": "^1.3.4",
         "jsonld-context-parser": "^2.1.5",
@@ -25806,7 +25809,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.0.1.tgz",
           "integrity": "sha512-/YOn4+5JEawI29h9eFYb9rScCtiLIK4TG+MrXpbJlHDjL8W34+V/RQoXqeau4SFXtA60Vzc7LRokefguh+I37Q==",
-          "peer": true,
+          "dev": true,
           "requires": {
             "@rdfjs/types": "*",
             "@types/sparqljs": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-jest": "^25.3.0",
     "husky": "^7.0.4",
     "jest": "^27.4.5",
+    "ldflex": "^2.13.1",
     "mkdirp": "^1.0.4",
     "n3": "^1.12.2",
     "semantic-release": "^18.0.1",

--- a/src/ComunicaEngine.js
+++ b/src/ComunicaEngine.js
@@ -13,27 +13,31 @@ export default class ComunicaEngine {
   constructor(defaultSource, settings = {}) {
     this._engine = settings.engine ? settings.engine : newEngine();
     // Preload sources but silence errors; they will be thrown during execution
-    this._sources = this.parseSources(defaultSource);
-    this._destination = settings.destination ? this.parseSources(settings.destination) : this._sources;
-    this._sources.catch(() => null);
+    this._sources = this.parseSourcesSilent(defaultSource);
+    this._destination = settings.destination && this.parseSourcesSilent(settings.destination);
     this._options = settings.options ? settings.options : {};
+  }
+
+  parseSourcesSilent(sources) {
+    const parsedSources = this.parseSources(sources);
+    parsedSources.catch(() => null);
+    return parsedSources;
   }
 
   /**
    * Creates an asynchronous iterable of results for the given SPARQL query.
    */
   async* execute(sparql, source) {
+    // Load the sources if passed, the default sources otherwise
+    const sources = await this.parseSources(source, this._sources);
+
     if ((/^\s*(?:INSERT|DELETE)/i).test(sparql)) {
       yield* this.executeUpdate(sparql, source);
     }
-    else {
-      // Load the sources if passed, the default sources otherwise
-      const sources = await (source ? this.parseSources(source) : this._sources);
-      if (sources.length !== 0) {
-        // Execute the query and yield the results
-        const queryResult = await this._engine.query(sparql, { sources, ...this._options });
-        yield* this.streamToAsyncIterable(queryResult.bindingsStream);
-      }
+    else if (sources.length !== 0) {
+      // Execute the query and yield the results
+      const queryResult = await this._engine.query(sparql, { sources, ...this._options });
+      yield* this.streamToAsyncIterable(queryResult.bindingsStream);
     }
   }
 
@@ -41,29 +45,43 @@ export default class ComunicaEngine {
    * Creates an asynchronous iterable with the results of the SPARQL UPDATE query.
    */
   async* executeUpdate(sparql, source) {
-    // Load the sources if passed, the default sources otherwise
-    let sources = await (source ? this.parseSources(source) : this._destination);
-    if (sources.length !== 0) {
-      // Update queries can only handle a single source
-      if (sources.length > 1)
-        sources = [sources[0]];
-      // Execute the query and yield the results
-      const queryResult = await this._engine.query(sparql, { sources, ...this._options });
-      if (queryResult.type !== 'update')
-        throw new Error(`Update query returned unexpected result type: ${queryResult.type}`);
+    let sources;
+    // Need to await the destination
+    const destination = await this._destination;
 
-      // Resolves when the update is complete
-      return queryResult.updateResult;
+    // Set the appropriate destination
+    if (!source && destination) {
+      if (destination.length !== 1)
+        throw new Error(`Destination must be a single source, not ${destination.length}`);
+
+      sources = destination;
     }
+    else {
+      // Load the sources if passed, the default sources otherwise
+      const _sources = await this.parseSources(source, this._sources);
+
+      if (_sources.length === 0)
+        throw new Error('At least one source must be specified: Updates are inserted into the first given data source if no destination is specified, or if using explicit sources for query');
+
+      sources = [_sources[0]];
+    }
+
+    // Execute the query and yield the results
+    const queryResult = await this._engine.query(sparql, { sources, ...this._options });
+    if (queryResult.type !== 'update')
+      throw new Error(`Update query returned unexpected result type: ${queryResult.type}`);
+
+    // Resolves when the update is complete
+    return queryResult.updateResult;
   }
 
   /**
    * Parses the source(s) into an array of Comunica sources.
    */
-  async parseSources(source) {
+  async parseSources(source, defaultSources = []) {
     let sources = await source;
     if (!sources)
-      return [];
+      return defaultSources;
 
     // Transform URLs or terms into strings
     if (sources instanceof URL)

--- a/test/ComunicaEngine-test.js
+++ b/test/ComunicaEngine-test.js
@@ -123,18 +123,6 @@ describe('An ComunicaEngine instance without default source', () => {
     await expect(readAll(result)).rejects.toThrow('Parse error');
   });
 
-  it('does not support INSERT queries', async () => {
-    const result = engine.execute('INSERT DATA { <a> <b> <c> }', PROFILE_URL);
-    await expect(readAll(result)).rejects
-      .toThrow('SPARQL UPDATE queries are unsupported, received: INSERT DATA { <a> <b> <c> }');
-  });
-
-  it('does not support DELETE queries', async () => {
-    const result = engine.execute(' delete data { <a> <b> <c> }', PROFILE_URL);
-    await expect(readAll(result)).rejects
-      .toThrow('SPARQL UPDATE queries are unsupported, received:  delete data { <a> <b> <c> }');
-  });
-
   it('reads an ended stream', async () => {
     const stream = new Readable();
     stream.push(null);

--- a/test/Update-test.js
+++ b/test/Update-test.js
@@ -1,6 +1,5 @@
 /** @jest-environment setup-polly-jest/jest-environment-node */
 
-
 import { namedNode, quad } from '@rdfjs/data-model';
 import { Store } from 'n3';
 import ComunicaEngine from '../src/ComunicaEngine';
@@ -41,10 +40,9 @@ describe('A ComunicaEngine instance without default source', () => {
     ))).toBe(true);
   });
 
-  it('supports INSERT queries (no sources)', async () => {
+  it('throws error on INSERT queries when no sources are provided', async () => {
     const result = engine.execute('INSERT DATA { <http://a> <http://b> <http://c> }');
-    const data = await readAll(result);
-    expect(data).toEqual([]);
+    await expect(() => readAll(result)).rejects.toThrowError('At least one source must be specified: Updates are inserted into the first given data source if no destination is specified, or if using explicit sources for query');
   });
 
   it('supports DELETE queries', async () => {
@@ -146,5 +144,102 @@ describe('A ComunicaEngine instance with one default source and different update
     const result = engine.executeUpdate(SELECT_TYPES);
     await expect(readAll(result)).rejects.toThrow('Update query returned unexpected result type: bindings');
     expect(store.getQuads()).toEqual([]);
+  });
+});
+
+describe('A ComunicaEngine instance with one default source and an empty destination', () => {
+  let engine;
+  let store;
+  let updateStore;
+
+  beforeEach(() => {
+    store = new Store();
+    updateStore = new Store();
+    engine = new ComunicaEngine(store, {
+      destination: [],
+    });
+  });
+
+  it('supports INSERT queries when explicit source is provided', async () => {
+    const result = engine.execute('INSERT DATA { <http://a> <http://b> <http://c> }', [updateStore]);
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(updateStore.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(true);
+    expect(store.getQuads()).toEqual([]);
+  });
+
+  it('supports DELETE queries when explicit source is provided', async () => {
+    const result = engine.execute(' delete data { <http://a> <http://b> <http://c> }', [updateStore]);
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(updateStore.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(false);
+    expect(store.getQuads()).toEqual([]);
+  });
+
+  it('errors on INSERT queries when no explicit source is provided', async () => {
+    const result = engine.execute(' delete data { <http://a> <http://b> <http://c> }');
+    await expect(() => readAll(result)).rejects.toThrowError('Destination must be a single source, not 0');
+  });
+
+  it('executeUpdate errors on SELECT query', async () => {
+    const result = engine.executeUpdate(SELECT_TYPES);
+    await expect(() => readAll(result)).rejects.toThrow('Destination must be a single source, not 0');
+  });
+});
+
+
+describe('A ComunicaEngine instance with one default source and 2 destinations', () => {
+  let engine;
+  let store;
+  let updateStore;
+
+  beforeEach(() => {
+    store = new Store();
+    updateStore = new Store();
+    engine = new ComunicaEngine(store, {
+      destination: [new Store(), new Store()],
+    });
+  });
+
+  it('supports INSERT queries when explicit source is provided', async () => {
+    const result = engine.execute('INSERT DATA { <http://a> <http://b> <http://c> }', [updateStore]);
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(updateStore.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(true);
+    expect(store.getQuads()).toEqual([]);
+  });
+
+  it('supports DELETE queries when explicit source is provided', async () => {
+    const result = engine.execute(' delete data { <http://a> <http://b> <http://c> }', [updateStore]);
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(updateStore.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(false);
+    expect(store.getQuads()).toEqual([]);
+  });
+
+  it('errors on INSERT queries when no explicit source is provided', async () => {
+    const result = engine.execute(' delete data { <http://a> <http://b> <http://c> }');
+    await expect(() => readAll(result)).rejects.toThrowError('Destination must be a single source, not 2');
+  });
+
+  it('executeUpdate errors on SELECT query', async () => {
+    const result = engine.executeUpdate(SELECT_TYPES);
+    await expect(() => readAll(result)).rejects.toThrow('Destination must be a single source, not 2');
   });
 });

--- a/test/Update-test.js
+++ b/test/Update-test.js
@@ -1,0 +1,150 @@
+/** @jest-environment setup-polly-jest/jest-environment-node */
+
+
+import { namedNode, quad } from '@rdfjs/data-model';
+import { Store } from 'n3';
+import ComunicaEngine from '../src/ComunicaEngine';
+import { mockHttp, readAll } from './util';
+
+const SELECT_TYPES = `
+  SELECT ?subject ?type WHERE {
+    ?subject a ?type.
+  }
+`;
+
+describe('A ComunicaEngine instance without default source', () => {
+  const engine = new ComunicaEngine();
+
+  mockHttp();
+
+  it('supports INSERT queries', async () => {
+    const store = new Store();
+    const result = engine.execute('INSERT DATA { <http://a> <http://b> <http://c> }', store);
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(store.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(true);
+  });
+
+  it('supports INSERT queries (multiple sources)', async () => {
+    const store = new Store();
+    const result = engine.execute('INSERT DATA { <http://a> <http://b> <http://c> }', [store, new Store()]);
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(store.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(true);
+  });
+
+  it('supports INSERT queries (no sources)', async () => {
+    const result = engine.execute('INSERT DATA { <http://a> <http://b> <http://c> }');
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+  });
+
+  it('supports DELETE queries', async () => {
+    const store = new Store();
+    const result = engine.execute(' delete data { <http://a> <http://b> <http://c> }', store);
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(store.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(false);
+  });
+
+  it('executeUpdate errors on SELECT query', async () => {
+    const store = new Store();
+    const result = engine.executeUpdate(SELECT_TYPES, store);
+    await expect(readAll(result)).rejects.toThrow('Update query returned unexpected result type: bindings');
+  });
+});
+
+
+describe('A ComunicaEngine instance with one default source', () => {
+  let engine;
+  let store;
+
+  beforeEach(() => {
+    store = new Store();
+    engine = new ComunicaEngine(store);
+  });
+
+  it('supports INSERT queries', async () => {
+    const result = engine.execute('INSERT DATA { <http://a> <http://b> <http://c> }');
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(store.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(true);
+  });
+
+  it('supports DELETE queries', async () => {
+    const result = engine.execute(' delete data { <http://a> <http://b> <http://c> }');
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(store.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(false);
+  });
+
+  it('executeUpdate errors on SELECT query', async () => {
+    const result = engine.executeUpdate(SELECT_TYPES);
+    await expect(readAll(result)).rejects.toThrow('Update query returned unexpected result type: bindings');
+  });
+});
+
+
+describe('A ComunicaEngine instance with one default source and different update source', () => {
+  let engine;
+  let store;
+  let updateStore;
+
+  beforeEach(() => {
+    store = new Store();
+    updateStore = new Store();
+    engine = new ComunicaEngine(store, {
+      destination: updateStore,
+    });
+  });
+
+  it('supports INSERT queries', async () => {
+    const result = engine.execute('INSERT DATA { <http://a> <http://b> <http://c> }');
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(updateStore.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(true);
+    expect(store.getQuads()).toEqual([]);
+  });
+
+  it('supports DELETE queries', async () => {
+    const result = engine.execute(' delete data { <http://a> <http://b> <http://c> }');
+    const data = await readAll(result);
+    expect(data).toEqual([]);
+    expect(updateStore.has(quad(
+      namedNode('http://a'),
+      namedNode('http://b'),
+      namedNode('http://c'),
+    ))).toBe(false);
+    expect(store.getQuads()).toEqual([]);
+  });
+
+  it('executeUpdate errors on SELECT query', async () => {
+    const result = engine.executeUpdate(SELECT_TYPES);
+    await expect(readAll(result)).rejects.toThrow('Update query returned unexpected result type: bindings');
+    expect(store.getQuads()).toEqual([]);
+  });
+});

--- a/test/integration/Update-test.js
+++ b/test/integration/Update-test.js
@@ -1,0 +1,34 @@
+/** @jest-environment setup-polly-jest/jest-environment-node */
+
+import { namedNode, quad } from '@rdfjs/data-model';
+import { Store } from 'n3';
+import ComunicaEngine from '../../src/ComunicaEngine';
+const { PathFactory } = require('ldflex');
+
+// The JSON-LD context for resolving properties
+const context = {
+  '@context': {
+    '@vocab': 'http://xmlns.com/foaf/0.1/',
+    'friends': 'knows',
+  },
+};
+
+const ALICE = namedNode('https://alice.org/profile/#me');
+const KNOWS = namedNode('http://xmlns.com/foaf/0.1/knows');
+const BOB = namedNode('https://bob.org/profile/#me');
+
+describe('A ComunicaEngine instance with one default source', () => {
+  let alice;
+  let store;
+
+  beforeEach(() => {
+    store = new Store();
+    const path = new PathFactory({ context, queryEngine: new ComunicaEngine(store) });
+    alice = path.create({ subject: ALICE });
+  });
+
+  it('supports .add handler', async () => {
+    await alice.friends.add(BOB);
+    expect(store.has(quad(ALICE, KNOWS, BOB))).toBe(true);
+  });
+});


### PR DESCRIPTION
Supercedes #80 (created a new branch to avoid rebasing issues).

Closes #77 .

Allows SPARQL update queries so that LDflex mutation handlers can be used.

It is likely that this will deprecate the [Solid Update Engine](https://github.com/LDflex/Query-Solid/blob/master/src/SolidUpdateEngine.js).


The current behavior is that by default the source given is also used as the destination for updates (if multiple sources are given, then the first one is chosen).

Optionally you can specify your own destination for updates as follows

```JavaScript
// The query engine and its source
const queryEngine = new ComunicaEngine(
    'https://ruben.verborgh.org/profile/',
    { destination: 'https://example.org/destination' },
  );
```

I note that this *differs* from the design of the Solid Update Engine - which requires that exactly one source be provided in order to perform updates - and errors otherwise.
